### PR TITLE
Add raw param to dog facts api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For questions or support, please contact directly through Twitter `https://twitt
 | Path         | Description  | Parameters
 | ------------ | ------------ | ----------
 | `/api/facts` | Returns an object with dog facts | `?number=5`
+| `/api/facts?raw=true` | Returns one fact in plain text 
 
 ## Host it yourself
 First make sure you have the following dependencies installed.

--- a/app.rb
+++ b/app.rb
@@ -41,6 +41,10 @@ get '/api/facts' do
     success_response = false
   end
 
+  if params[:raw]
+    return facts
+  end
+
   { facts: facts, success: success_response }.to_json
 end
 

--- a/app.rb
+++ b/app.rb
@@ -33,9 +33,10 @@ get '/api/facts' do
 
   facts = []
   success_response = false
+  count = params[:raw] ? 1 : params[:number]
 
   begin
-    random_facts = Fact.get_random(params[:number])
+    random_facts = Fact.get_random(count)
     facts = random_facts.map{|f| f.body }
     success_response = true
   rescue Exception => e

--- a/app.rb
+++ b/app.rb
@@ -29,6 +29,7 @@ end
 
 get '/api/facts' do
   content_type 'application/json', 'charset' => 'utf-8'
+  content_type 'text/plain', 'charset' => 'utf-8' if params[:raw] == 'true'
 
   facts = []
   success_response = false
@@ -41,9 +42,7 @@ get '/api/facts' do
     success_response = false
   end
 
-  if params[:raw]
-    return facts
-  end
+  return facts if params[:raw] == 'true'
 
   { facts: facts, success: success_response }.to_json
 end

--- a/app.rb
+++ b/app.rb
@@ -28,12 +28,13 @@ get '/' do
 end
 
 get '/api/facts' do
+  is_raw = params[:raw] == 'true'
   content_type 'application/json', 'charset' => 'utf-8'
-  content_type 'text/plain', 'charset' => 'utf-8' if params[:raw] == 'true'
+  content_type 'text/plain', 'charset' => 'utf-8' if is_raw
 
   facts = []
   success_response = false
-  count = params[:raw] ? 1 : params[:number]
+  count = is_raw ? 1 : params[:number]
 
   begin
     random_facts = Fact.get_random(count)
@@ -43,7 +44,7 @@ get '/api/facts' do
     success_response = false
   end
 
-  return facts if params[:raw] == 'true'
+  return facts if is_raw
 
   { facts: facts, success: success_response }.to_json
 end


### PR DESCRIPTION
* As requested in https://github.com/kinduff/dog-api/issues/8
* `/api/facts` now accepts a `raw` param which if exists will only return a text version of fact (no JSON)

With `/api/facts?raw=True`:

![image](https://user-images.githubusercontent.com/7072946/183520708-739566a9-7b94-4bf6-b051-429769104e3d.png)


Without:
![image](https://user-images.githubusercontent.com/7072946/183520736-b3e29859-fc35-437f-b98f-6c94f7154247.png)



Disclaimer: Writing Ruby for the first time, let me know if this is not right. 👍 